### PR TITLE
feat: add an API_KEY requirement for security purpose

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -5,3 +5,6 @@ export AWS_BUCKET_NAME=!ChangeMe!
 # Silverlining (QR Code generation)
 export SILVERLINING_URL=!ChangeMe!
 export SILVERLINING_API_KEY=!ChangeMe!
+
+# Local API key for security purpose
+export API_KEY=!ChangeMe!

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,1 +1,2 @@
+pub mod app_config;
 pub mod routes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use crate::adapters::aws_config::AwsConfig;
+use crate::api::app_config::AppConfig;
 use crate::api::routes::{configure_routes, AppState};
 use actix_web::{web, App, HttpServer};
 use log::info;
@@ -14,11 +15,13 @@ async fn main() -> std::io::Result<()> {
     info!("Starting ODO Orchestrator API...");
 
     let aws_config = AwsConfig::new();
+    let app_config = AppConfig::new();
 
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(AppState {
                 aws_config: aws_config.clone(),
+                app_config: app_config.clone(),
             }))
             .configure(configure_routes)
     })


### PR DESCRIPTION
This PR adds an API_KEY to be used in the Request headers, as a requirement for API usage.